### PR TITLE
Switch to VictoriaMetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Go 1.22
 **Configuration:**  
 Set emb_dir and node_bin variables in start.sh
 
-**Prometheus setup:**  
-Run install.sh in apps/prometheus
+**VictoriaMetrics setup:**
+Run install.sh in apps/victoriametrics
 
 **Systemd setup:**  
 Create a /etc/emb folder  
@@ -44,8 +44,8 @@ Build remix app `npm run build`
 
 ## Ports
 
-node: 3000  
-grafana: 3001  
-prometheus: 2112  
-loki: 3100  
-promtial: 9080  
+node: 3000
+grafana: 3001
+victoria-metrics: 8428
+loki: 3100
+promtial: 9080

--- a/apps/docker-compose.yaml
+++ b/apps/docker-compose.yaml
@@ -34,20 +34,17 @@ services:
     environment:
       - "ESI_CACHE=/esi-cache"
 
-#  prometheus:
-#    image: prom/prometheus:latest
-#    restart: no
-#    ports:
-#      - "9090:9090"
-#      - "2112:2112"
-#    volumes:
-#      - ./prometheus/prometheus.yml:/etc/prometheus.yml
-#      - ./prometheus/data:/prometheus
-#    command:
-#      - '--config.file=/etc/prometheus/prometheus.yml'
-#      - '--storage.tsdb.path=/prometheus'
-#      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
-#      - '--web.console.templates=/usr/share/prometheus/consoles'
+
+  victoria-metrics:
+    image: victoriametrics/victoria-metrics:latest
+    restart: no
+    ports:
+      - "8428:8428"
+    volumes:
+      - ./victoriametrics/prometheus.yml:/etc/prometheus.yml
+      - ./victoriametrics/data:/victoria-metrics-data
+    command:
+      - '--promscrape.config=/etc/prometheus.yml'
 
   grafana:
     image: grafana/grafana:latest

--- a/start.sh
+++ b/start.sh
@@ -8,8 +8,8 @@ node_bin=/home/raph/.nvm/versions/node/v22.2.0/bin/node
 export ESI_CACHE=$emb_dir/apps/website/esi-cache
 export NODE_ENV=production
 
-cd $emb_dir/apps/prometheus
-./prometheus --config.file=./prometheus.yml &>> $emb_dir/prometheus.log &
+cd $emb_dir/apps/victoriametrics
+./victoria-metrics-prod --promscrape.config=./prometheus.yml &>> $emb_dir/victoria.log &
 
 cd $emb_dir/apps/store
 ./store &>> $emb_dir/store.log &


### PR DESCRIPTION
## Summary
- replace Prometheus instructions with VictoriaMetrics
- swap ports list for new metrics endpoint
- add VictoriaMetrics service to docker-compose
- update start script to run VictoriaMetrics

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6859da09edf88325b0b75532c2e89fbc